### PR TITLE
Fix route handler context types

### DIFF
--- a/app/api/admin/products/[id]/route.ts
+++ b/app/api/admin/products/[id]/route.ts
@@ -2,10 +2,9 @@ import { NextRequest, NextResponse } from 'next/server';
 
 export async function PUT(
   req: NextRequest,
-  { params }: { params: { id: string } }
+  context: { params: Promise<{ id: string }> }
 ) {
-  // En Next.js 15, params ya no es una Promise para rutas simples como [id]
-  const { id } = params;
+  const { id } = await context.params;
   const body = await req.json();
 
   const {
@@ -58,10 +57,9 @@ export async function PUT(
 
 export async function DELETE(
   req: NextRequest,
-  { params }: { params: { id: string } }
+  context: { params: Promise<{ id: string }> }
 ) {
-  // En Next.js 15, params ya no es una Promise para rutas simples como [id]
-  const { id } = params;
+  const { id } = await context.params;
 
   try {
     const res = await fetch(

--- a/app/api/admin/users/[id]/route.ts
+++ b/app/api/admin/users/[id]/route.ts
@@ -2,9 +2,9 @@ import { NextRequest, NextResponse } from "next/server";
 
 export async function PUT(
   req: NextRequest,
-  { params }: { params: { id: string } }
+  context: { params: Promise<{ id: string }> }
 ) {
-  const id = params.id;
+  const { id } = await context.params;
 
   try {
     const body = await req.json();

--- a/app/api/pedidos/[id]/route.ts
+++ b/app/api/pedidos/[id]/route.ts
@@ -3,9 +3,9 @@ import { NextRequest, NextResponse } from "next/server";
 
 export async function PUT(
   req: NextRequest,
-  { params }: { params: Record<string, string> }
+  context: { params: Promise<Record<string, string>> }
 ) {
-  const documentId = params.id;
+  const { id: documentId } = await context.params;
 
   try {
     const body = await req.json();


### PR DESCRIPTION
## Summary
- update admin products, users, and pedidos API routes to match Next.js 15 route handler context typings

## Testing
- `npx tsc --noEmit` *(fails: numerous unrelated type errors)*

------
https://chatgpt.com/codex/tasks/task_e_688d138ff7b88321a8aa80ec0111bd05